### PR TITLE
#17: Enable template-cloning

### DIFF
--- a/includes/functions/zca_bootstrap_functions.php
+++ b/includes/functions/zca_bootstrap_functions.php
@@ -5,9 +5,10 @@
  
 // -----
 // This function returns a boolean value indicating whether (true) or not (false)
-// the ZCA bootstrap template is the currently-active template.
+// the ZCA bootstrap template is the currently-active template.  The definition is
+// present in the template's /includes/languages/english/extra_definitions/zca_bootstrap_id.php,
 //
 function zca_bootstrap_active()
 {
-    return (isset($GLOBALS['template_dir']) && $GLOBALS['template_dir'] == 'bootstrap');
+    return (defined('IS_ZCA_BOOTSTRAP_TEMPLATE'));
 }

--- a/includes/languages/english/extra_definitions/bootstrap/zca_bootstrap_id.php
+++ b/includes/languages/english/extra_definitions/bootstrap/zca_bootstrap_id.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * 
+ * zca_bootstrap_id.php
+ *
+ * @copyright Copyright 2018 zcadditions.com/vinosdefrutastropicales.com
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+// -----
+// The presence of the following definition identifies the template as either
+// the ZCA "Bootstrap" template, or a clone thereof.  See GitHub#17 in the
+// template's GitHub repository for additional information.
+//
+// Note: It doesn't matter what value is set, just that the definition exists
+// for the template's zca_bootstrap_active function's use.  That function will
+// identify the current template as a "bootstrap" one, if the definition is
+// present.
+//
+define('IS_ZCA_BOOTSTRAP_TEMPLATE', 'true');


### PR DESCRIPTION
An additional file (/includes/languages/english/extra_definitions/bootstrap/zca_bootstrap_id.php) is added.  That file contains a single definition, the presence of which identifies the template as bootstrap or a clone.