### PR TITLE
Implement updated regex quoting from ZC core

### DIFF
--- a/includes/modules/bootstrap/additional_images.php
+++ b/includes/modules/bootstrap/additional_images.php
@@ -64,7 +64,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
                     $current_image_match
                 );
                 if ($current_image_match || substr($file, strrpos($file, '.')) == $file_extension) {
-                    if ($current_image_match || preg_match('/\Q' . $products_image_base . '\E/i', $file) == 1) {
+                    if ($current_image_match || preg_match('/' . preg_quote($products_image_base, '/') . '/i', $file) == 1) {
                         if ($current_image_match || $file != $products_image) {
                             if ($products_image_base . str_replace($products_image_base, '', $file) == $file) {
                                 //  echo 'I AM A MATCH ' . $file . '<br>';

--- a/includes/modules/bootstrap/bootstrap_additional_images.php
+++ b/includes/modules/bootstrap/bootstrap_additional_images.php
@@ -48,7 +48,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
     while ($file = $dir->read()) {
       if (!is_dir($products_image_directory . $file)) {
         if (substr($file, strrpos($file, '.')) == $file_extension) {
-          if(preg_match('/\Q' . $products_image_base . '\E/i', $file) == 1) {
+          if(preg_match('/' . preg_quote($products_image_base, '/') . '/i', $file) == 1) {
             if ($file != $products_image) {
               if ($products_image_base . str_replace($products_image_base, '', $file) == $file) {
                 //  echo 'I AM A MATCH ' . $file . '<br>';

--- a/includes/modules/bootstrap/bootstrap_slide_additional_images.php
+++ b/includes/modules/bootstrap/bootstrap_slide_additional_images.php
@@ -48,7 +48,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
     while ($file = $dir->read()) {
       if (!is_dir($products_image_directory . $file)) {
         if (substr($file, strrpos($file, '.')) == $file_extension) {
-          if(preg_match('/\Q' . $products_image_base . '\E/i', $file) == 1) {
+          if(preg_match('/' . preg_quote($products_image_base, '/') . '/i', $file) == 1) {
             if ($file != $products_image) {
               if ($products_image_base . str_replace($products_image_base, '', $file) == $file) {
                 //  echo 'I AM A MATCH ' . $file . '<br>';


### PR DESCRIPTION
I've been running into cases where the special regex chars `\Q...\E` for escaping aren't consistently handling all the necessary characters (including `/`), but the general practice of `preq_quote`-ing resolves it. 

This PR updates this template to match the recent updates to ZC core to use `preg_quote` in the image matching process.