### PR TITLE
#48: Restore classes to order-totals' display

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_modules_order_totals.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_order_totals.php
@@ -17,7 +17,7 @@
  */
   for ($i=0; $i<$size; $i++) { ?>
 
-    <tr>
+    <tr id="<?php echo str_replace('_', '', $GLOBALS[$class]->code); ?>">
 <td colspan="2" class="text-right bg-white">
 <?php echo $GLOBALS[$class]->output[$i]['title']; ?>
 </td>


### PR DESCRIPTION
To resolve an interoperability issue with One-Page Checkout.